### PR TITLE
Add arvancloud .ir domains

### DIFF
--- a/src/data/custom_domains.py
+++ b/src/data/custom_domains.py
@@ -5,6 +5,8 @@ custom_domains = {
     "direct": [
         "bpi.ir",
         "arvancdn.com",
+        "arvancdn.ir",
+        "arvancloud.ir",
         "blubank.com",
         "cedarmaps.com",
         "digikalacloud.com",


### PR DESCRIPTION
Arvancloud changed its domains to .ir TLD. So I added 2 domains belonged to Arvancloud (I don't know any other domains)
