### PR TITLE
Add enamad as a source

### DIFF
--- a/README.fa.md
+++ b/README.fa.md
@@ -294,7 +294,8 @@ go run ./ --outputdir=../
 ## منابع و گرامیداشت
 
 - دامنه‌های ایران:
-  - [سازمان فناوری اطلاعات ایران](https://g2b.ito.gov.ir/index.php/site/list_ip)
+  - [سازمان فناوری اطلاعات ایران](https://eservices.ito.gov.ir/page/iplist) - [Mirror](https://github.com/bootmortis/ito-gov-mirror)
+  - [اینماد](https://enamad.ir/DomainListForMIMT) - [Mirror](https://github.com/bootmortis/enamad-mirror)
   - [سامانه مدیریت اینترنت مشتریان شرکت مخابرات ایران](https://adsl.tci.ir/panel/sites)
   - مخزن [V2fly Domain List Community](https://github.com/v2fly/domain-list-community) (لایسنس MIT)
   - [لیست شخصی][link-custom]

--- a/README.md
+++ b/README.md
@@ -295,6 +295,7 @@ go run ./ --outputdir=../
 
 - Iran Domains:
   - [ITO GOV](https://eservices.ito.gov.ir/page/iplist) - [Mirror](https://github.com/bootmortis/ito-gov-mirror)
+  - [Enamad](https://enamad.ir/DomainListForMIMT) - [Mirror](https://github.com/bootmortis/enamad-mirror)
   - [ADSL TCI](https://adsl.tci.ir/panel/sites)
   - [V2fly Domain List Community](https://github.com/v2fly/domain-list-community) (MIT License)
   - [Custom List][link-custom]

--- a/src/constants.py
+++ b/src/constants.py
@@ -2,6 +2,8 @@
 g2b_gov_url = "https://raw.githubusercontent.com/bootmortis/ito-gov-mirror/main/out/domains.csv"
 ads_url = "https://raw.githubusercontent.com/nimasaj/uBOPa/master/uBOPa_Pihole.txt"
 v2fly_base_url = "https://raw.githubusercontent.com/v2fly/domain-list-community/master/data/"
+# https://enamad.ir/DomainListForMIMT
+enamad_url = "https://raw.githubusercontent.com/bootmortis/enamad-mirror/main/out/domains.csv"
 
 # input files
 adsl_tci_file_path = "src/data/adsl_tci.txt"

--- a/src/get_domians.py
+++ b/src/get_domians.py
@@ -16,6 +16,14 @@ def g2b_ito_gov() -> Iterable[str]:
     domains = (domain.split(',')[0] for domain in domains)
     return list(set(domains))
 
+def enamad() -> Iterable[str]:
+    resp = requests.get(consts.enamad_url)
+    resp.raise_for_status()
+
+    domains = resp.text
+    domains = domains.splitlines()[1:]
+    domains = (domain.split(',')[2] for domain in domains)
+    return list(set(domains))
 
 def adsl_tci() -> Iterable[str]:
     with open(consts.adsl_tci_file_path, "r") as file:

--- a/src/main.py
+++ b/src/main.py
@@ -43,6 +43,7 @@ if __name__ == "__main__":
     # Request data from sources and cleanup
     all_domains = collect_and_clean_domains(
         get_domians.g2b_ito_gov(),
+        get_domians.enamad(),
         get_domians.adsl_tci(),
         get_domians.v2fly(),
     )


### PR DESCRIPTION
## Description

Added [enamad domain list](https://enamad.ir/DomainListForMIMT) ([Mirror](https://github.com/bootmortis/enamad-mirror)) as a source for Iran-hosted domains.

## Related Issues

#43 

## Checklist

- [x] I have read and followed the [contributing guidelines](/CONTRIBUTING.md).
- [x] I have tested my changes.
- [x] I have updated the documentation, if necessary.

## Additional Information

Domains count raises from ~28,100 domains to ~92,900
Tested with SwitchyOmega ✅
