### PR TITLE
Update custom_domains.py

### DIFF
--- a/src/data/custom_domains.py
+++ b/src/data/custom_domains.py
@@ -121,6 +121,7 @@ custom_domains = {
         "microless.shop",
         "boomidi.net",
         "shab.cloud",
+        "kermanmotor.com",
     ],
     "remove": [
         "googleapis.com",

--- a/src/data/custom_domains.py
+++ b/src/data/custom_domains.py
@@ -115,6 +115,12 @@ custom_domains = {
         "bittestan.com",
         "bitmax.ir",
         "erythron.net",
+        "arvanstorage.com",
+        "digijojeh.com",
+        "masirwp.com",
+        "microless.shop",
+        "boomidi.net",
+        "shab.cloud"
     ],
     "remove": [
         "googleapis.com",

--- a/src/data/custom_domains.py
+++ b/src/data/custom_domains.py
@@ -120,7 +120,7 @@ custom_domains = {
         "masirwp.com",
         "microless.shop",
         "boomidi.net",
-        "shab.cloud"
+        "shab.cloud",
     ],
     "remove": [
         "googleapis.com",


### PR DESCRIPTION
## Added These domains:


### **arvanstorage.com:**
When using `arvancloud.ir`, this domain is constantly requested but it's proxied. this domain should be directed.

### **digijojeh.com:**
The host is in Iran and won't open with proxy.

### **masirwp.com:**
Used alongside with Iranian domain for website-building and hosting.
 
### **microless.shop:**
When opening `microless.ir`, which is an Iranian shopping website hosted in Iran, this domain is constantly requested but because it's proxied the website load time is very high and laggy. This domain should be directed.

### **boomidi.net:**
Hosted in Iran and won't open with a proxy.

### **shab.cloud:**
It's like a CDN and hosting for `shab.ir`. with some proxies, images on `shab.ir` won't load. This domain should be directed.
