### PR TITLE
Update custom_domains.py

### DIFF
--- a/src/data/custom_domains.py
+++ b/src/data/custom_domains.py
@@ -105,7 +105,6 @@ custom_domains = {
         "adnetwork.credit",
         "shahrad.net",
         "khanesony.co",
-        "ijmarket.com"
     ],
     "remove": [
         "googleapis.com",

--- a/src/data/custom_domains.py
+++ b/src/data/custom_domains.py
@@ -100,6 +100,12 @@ custom_domains = {
         "cafeartini.com",
         "ir.archive.ubuntu.com",
         "ir.prod.hosts.ooklaserver.net",
+        "dadhotel.com",
+        "paystar.click",
+        "adnetwork.credit",
+        "shahrad.net",
+        "khanesony.co",
+        "ijmarket.com"
     ],
     "remove": [
         "googleapis.com",

--- a/src/data/custom_domains.py
+++ b/src/data/custom_domains.py
@@ -101,7 +101,6 @@ custom_domains = {
         "ir.archive.ubuntu.com",
         "ir.prod.hosts.ooklaserver.net",
         "dadhotel.com",
-        "paystar.click",
         "adnetwork.credit",
         "shahrad.net",
         "khanesony.co",


### PR DESCRIPTION
**Added:**

`dadhotel.com` 

`paystar.click` and ` adnetwork.credit`: These sites are essential for pay gateways located in Iran. such as buying an account from 30nama.com via an Iranian debit card. if they are proxified or blocked, some of the gateways won't work or process transactions.

`shahrad.net`

`ijmarket.com`

