### PR TITLE
Update custom_domains.py

### DIFF
--- a/src/data/custom_domains.py
+++ b/src/data/custom_domains.py
@@ -109,6 +109,7 @@ custom_domains = {
         "tapsi.cab",
         "tap30.services",
         "swiftsrv.net",
+        "rasayesh.com"
     ],
     "remove": [
         "googleapis.com",


### PR DESCRIPTION
Added `rasayesh.com` to the direct/bypass list.

This domain is used to be called with API in various Iranian websites, especially exhibition ceremonies.