### PR TITLE
Add mytendo.net domain

### DIFF
--- a/src/data/custom_domains.py
+++ b/src/data/custom_domains.py
@@ -100,6 +100,7 @@ custom_domains = {
         "mimfarsi.com",
         "mlt.link",
         "mojnews.com",
+        "mytendo.net",
         "nabzebourse.com",
         "namavid.com",
         "nassaab.com",


### PR DESCRIPTION
## Description
mytendo.net is an online shop for selling Nintendo products in Iran

## Checklist

- [x] I have read and followed the [contributing guidelines](/CONTRIBUTING.md).
- [x] I have tested my changes.
- [x] I have updated the documentation, if necessary.