### PR TITLE
add metrix.ir domain

### DIFF
--- a/src/data/custom_domains.py
+++ b/src/data/custom_domains.py
@@ -98,6 +98,7 @@ custom_domains = {
         "maryamsoft.com",
         "masirwp.com",
         "medrick.games",
+        "metrix.ir",
         "microless.shop",
         "mimfarsi.com",
         "mlt.link",


### PR DESCRIPTION
## Description
matrix.ir is the domain that Igap messenger uses to load advertisements.
## Checklist

- [x] I have read and followed the [contributing guidelines](/CONTRIBUTING.md).
- [x] I have tested my changes.
- [x] I have updated the documentation, if necessary.

