### PR TITLE
adding asr24.com

### DIFF
--- a/src/data/custom_domains.py
+++ b/src/data/custom_domains.py
@@ -42,6 +42,7 @@ custom_domains = {
         "asiamokamel.com",
         "asiatech.com",
         "asnafshahr.com",
+        "asr24.com",
         "azad.im",
         "azadfekrischool.ir",
         "azadilab.com",


### PR DESCRIPTION
asr24.com is used for qmb.ir mobile bank

The "Qard al-Hasanah Mahan Iran" bank application had an issue and wouldn’t open.
I inspected it using the PCAPdroid app on Android and noticed that in the list of domains it requests,
asr24.com
is also present, which is responsible for serving this app.
I tested it, and by directing the connection for this domain, the issue of the app not opening was resolved.