### PR TITLE
Add `smart-boom.com` to custom domains list

### DIFF
--- a/src/data/custom_domains.py
+++ b/src/data/custom_domains.py
@@ -494,6 +494,7 @@ custom_domains = {
         "silvesting.com",
         "simaye-salamat.com",
         "sinsamed.com",
+        "smart-boom.com",
         "snapp-food.com",
         "snapp.market",
         "snapp.site",


### PR DESCRIPTION
smart-boom.com is IoT domain for Daewoo appliances in Iran. (also there is an app with this name) this domain (and all subdomains have to be directed)