### PR TITLE
add `modemtak.com` and `smart-boom.com` domains

### DIFF
--- a/src/data/custom_domains.py
+++ b/src/data/custom_domains.py
@@ -348,6 +348,7 @@ custom_domains = {
         "mimfarsi.com",
         "mlt.link",
         "mobilefixcompany.com",
+        "modemtak.com",
         "mohtava.cloud",
         "mojnews.com",
         "mokammelyab.com",

--- a/src/data/custom_domains.py
+++ b/src/data/custom_domains.py
@@ -494,6 +494,7 @@ custom_domains = {
         "silvesting.com",
         "simaye-salamat.com",
         "sinsamed.com",
+        "smart-boom.com",
         "snapp-food.com",
         "snapp.market",
         "snapp.site",


### PR DESCRIPTION
add `modemtak.com` and `smart-boom.com` domains.

`smart-boom.com` is part of the daewoo appliance iot services in iran.